### PR TITLE
Revert "iteration 4 first half "

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@tailwindcss/typography": "^0.5.15",
         "appwrite": "^18.1.1",
         "chart.js": "^4.5.0",
-        "eruda": "^3.4.3",
         "netlify": "^23.5.1",
         "qrcode": "^1.5.4"
       },
@@ -1461,9 +1460,9 @@
       }
     },
     "node_modules/@sveltejs/adapter-netlify": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-5.2.4.tgz",
-      "integrity": "sha512-UtPcZq1HUA43hM8uLi+nsm5Q+YjHNj7/SMFoyeLZeY/VTloVWABEZ0tJ5WodTUmy/8j5QJ7oLZjj28aQxi8y3g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-5.2.3.tgz",
+      "integrity": "sha512-xO9qsChQqfncgsrXgQb3phGTpKhlyPn7jusnl/HJwKJqzmEZ/xB/dAa0qFqrp+LNxEA+FPE7rJg36cmBaydXSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1476,9 +1475,9 @@
       }
     },
     "node_modules/@sveltejs/adapter-static": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
-      "integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.9.tgz",
+      "integrity": "sha512-aytHXcMi7lb9ljsWUzXYQ0p5X1z9oWud2olu/EpmH7aCu4m84h7QLvb5Wp+CFirKcwoNnYvYWhyP/L8Vh1ztdw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1486,9 +1485,9 @@
       }
     },
     "node_modules/@sveltejs/adapter-vercel": {
-      "version": "5.10.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-5.10.3.tgz",
-      "integrity": "sha512-fW2ZhMiOrUKsJJhiB4ift9sYDSFWgvH3N22cjf8ukOyWgHolb9SmSS3owr+nHQNlgTEAdy4eIr4Fnasw3nkxTw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-vercel/-/adapter-vercel-5.10.2.tgz",
+      "integrity": "sha512-uWm0jtXbwvXxmELiIXSQ7tcPjlG8roadujxImIxqbKKZ64itZDwTbUsVXYEfUX59LvLjolW9jaODhL6sBTh5NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1500,9 +1499,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.46.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.46.2.tgz",
-      "integrity": "sha512-bGs473Gj4TwFf7dw6ZUwQI0ayaDb83E7G06QnYeNQC2DmAaktgFU2uB0tSfZVhpHqYH4o8GsLBkG3ZjThtmsIA==",
+      "version": "2.39.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.39.1.tgz",
+      "integrity": "sha512-NdgBGHcf/3tXYzPRyQuvsmjI5d3Qp6uhgmlN3uurhyEMN0hMFhdUG83zmWBH8u/QXj6VBmPrKvUn0QXf+Q3/lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2648,12 +2647,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/eruda": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eruda/-/eruda-3.4.3.tgz",
-      "integrity": "sha512-J2TsF4dXSspOXev5bJ6mljv0dRrxj21wklrDzbvPmYaEmVoC+2psylyRi70nUPFh1mTQfIBsSusUtAMZtUN+/w==",
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -17549,9 +17542,9 @@
       "license": "ISC"
     },
     "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18443,9 +18436,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@tailwindcss/typography": "^0.5.15",
     "appwrite": "^18.1.1",
     "chart.js": "^4.5.0",
-    "eruda": "^3.4.3",
     "netlify": "^23.5.1",
     "qrcode": "^1.5.4"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@
 		<meta name="description" content="Monytri" />
 		<meta charset="utf-8" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json" />
-		<meta name="theme-color" content="#AFA8E6"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover,user-scalable=0,interactive-widget=overlay-content" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/lib/Shared/molucule/Footer.svelte
+++ b/src/lib/Shared/molucule/Footer.svelte
@@ -323,20 +323,4 @@
 				z-index: 100;
 		}
     }
-
-	 @media not all and (display-mode: standalone) {
-	 	.mobile-nav{
-			grid-template-rows: min(0px, 15%) [content-start] 2fr [content-end] min(0px,20%);
-		}
-
-		.mobile-nav ul li {
-			padding: 2cqi;
-		}
-
-		.mobile-nav ul li:is(:hover,:focus-within,:visited),
-		.mobile-nav ul li:has(:is(a,button).active){
-			inset: 0;
-			border-radius: 50% ;
-		}
-	}
 </style>

--- a/src/lib/Shared/molucule/PageStepContainer_S.svelte
+++ b/src/lib/Shared/molucule/PageStepContainer_S.svelte
@@ -533,7 +533,7 @@
 			max-height: 100dvh;
 			gap: 1cqh;
 			padding: 0 ;
-			padding-block: 0 3% ;
+			padding-block: 3% ;
 			color: var(--general-text-color) !important;
 		}
 
@@ -690,20 +690,4 @@
 			text-align: center;
 		}		
 	}
-
-	/* come back to this  */
-	/* They should be able to check if the mobile container is scrollable. It should apply a lower margin to make sure that the endpoint of the content is above the footer.  */
-
-	/* @media not all and (display-mode: standalone){
-	
-		.mobile-step {
-			container-type: inline-size;
-
-			@container (width > 100px) {
-				padding-bottom: calc(var(--footer-height) + 2rem);
-				display:none !important;
-				background-color: red;
-			}
-		}
-	} */
 </style>

--- a/src/lib/Stock-overview-p/Announcements.svelte
+++ b/src/lib/Stock-overview-p/Announcements.svelte
@@ -124,11 +124,9 @@
 	line-height: 120%;
 }	
 
-@media 	(-webkit-min-device-pixel-ratio: 3) ,
-		(pointer: coarse) and (hover: none) and (min-resolution: 400dpi) and (display-mode: standalone)
-		/* (pointer: coarse) and (hover: none) and (min-resolution: 400dpi) and (display-mode: standalone), */
-		/* screen and (device-width <= 900px) and (width <= 900px) and (orientation: portrait), */
-		/* screen and (device-height <= 900px) and (height <= 900px) and (orientation: landscape)  */
+@media 	(-webkit-min-device-pixel-ratio: 3),
+	screen and (device-width < 900px) and (width <= 900px) and (orientation: portrait) , 
+	screen and (device-height <= 900px) and (height <= 900px) and  (orientation: landscape)
 	{
 		.announcements-list{
 			height: clamp(2dvh, 70dvh, 300vh);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,11 +31,6 @@
 			});
 		});
 	}
-
-	onMount(async () => {
-		const eruda = (await import("eruda")).default;
-		eruda.init(); 
-	});
 	
 
 	
@@ -140,7 +135,6 @@
 
 <svelte:head>
 	<title>Monytri {$current}</title>
-	<meta name="theme-color" content="red"/>
 </svelte:head>
 
 <!-- main application layout -->
@@ -182,7 +176,7 @@
 		--body-padding: 2%;
 		--header-height: calc(8dvh + var(--safe-area-inset-top));
 		--footer-height: calc(50px + var(--safe-area-inset-bottom));
-		--footer-height-2: minmax(316px,15lvh) ;
+		--footer-height-2: minmax(316px,15dvh) ;
 
 		/* all the elements that will be animated */
 		will-change: transform, height, background-color, box-shadow, border-radius,position;
@@ -217,8 +211,8 @@
 		padding: 0;
 		overflow-x: hidden;
 		overflow-y: auto;
-		max-height:100dvh;
-		height: 100dvh;
+		max-height:100svh;
+		height: 100svh;
 		overscroll-behavior-x: contain;
 		overscroll-behavior-y: contain;
 		color: var(--general-text-color);
@@ -228,7 +222,7 @@
 		display: grid;
 		grid-template-columns: var(--body-padding) [content-start] repeat(12,1fr) [content-end] var(--body-padding);
 		grid-template-rows: [header-start] var(--header-height) [header-end main-start] min(calc(100dvh - var(--header-height)),100%) [main-end footer-start] minmax(316px,15dvh) [footer-end];
-		min-height: 100lvh;
+		min-height: 100dvh;
 		background-color: var(--general-background-color);
 		overflow-x: clip;
 		/* overflow-y:auto; */
@@ -308,8 +302,7 @@
 
 		:global(body){
 			overflow: hidden;
-			max-height:100dvh;
-			background-color: var(--general-background-color);
+			max-height:100svh;
 		}
 
 		:global(.body-container){
@@ -416,7 +409,7 @@
 			bottom: -1px;
 			right: 0;
 			left: 0;
-			width: 100dvw;
+			width: 100lvw;
 			height: clamp(50px, 10dvh, var(--footer-height));
 			border-radius: var(--_nav-radius) var(--_nav-radius) 0 0;
 			transform: translate3d(0,0,0);
@@ -428,24 +421,4 @@
 			--footer-height: calc(60px + var(--safe-area-inset-bottom));
 		}
 	}
-
-	@media not all and (display-mode: standalone) {
-
-		:global(body){
-			overflow: hidden;
-			max-height:100lvh !important;
-			background-color: var(--general-background-color) !important;
-		}
-
-		:global(footer){
-			--footer-height: calc(20px + var(--safe-area-inset-bottom));
-
-			position: fixed;
-			bottom : calc(1dvh + env(safe-area-inset-bottom));
-			width: 85dvw;
-			align-self: center;
-			place-self: center;
-			border-radius: 1pc;
-		}
-	}	
 </style>

--- a/src/routes/stock-overview/+page.svelte
+++ b/src/routes/stock-overview/+page.svelte
@@ -221,7 +221,7 @@ screen and (device-height <= 900px) and (height <= 900px) and (orientation: land
 	.button-container-calculator {
 		position: fixed;
 		right: var(--body-padding);
-		bottom: calc(5px + var(--footer-height));
+		bottom: var(--footer-height);
 		z-index: 10;
 		width: 15vw;
 	}

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -177,4 +177,6 @@ li > span .transaction-route{
 	padding: 2rem;
 	color: #666;
 }
+
+
 </style>


### PR DESCRIPTION
Reverts christoph3r3w/Monytri-app#27

## Summary by Sourcery

Revert prior iteration 4 changes by removing debug tooling, standalone-mode styles, and theme-color tags while standardizing viewport units across the layout and components

Enhancements:
- Standardize viewport unit usage to dynamic units (svh, dvh, lvh, lvw) throughout layout and shared components
- Remove display-mode: standalone media query overrides and commented standalone styling blocks
- Drop eruda debug console initialization and related import in layout.svelte
- Eliminate theme-color meta tags from layout and index.html

Build:
- Remove eruda dependency from package.json